### PR TITLE
Add files and exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,16 @@
   ],
   "bugs": {
     "url": "https://github.com/weaviate/weaviate-breadboard-kit/issues"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "node": "./dist/index.cjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
   }
 }


### PR DESCRIPTION
This commit adds the "files" and "exports" fields to the package.json file. The "files" field includes the "dist" directory, while the "exports" field specifies different import paths for different environments.