### PR TITLE
Refactor tests to run in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\"",
     "lint": "eslint 'src/**/*.{ts,tsx}' --fix",
-    "test": "node --experimental-vm-modules node_modules/.bin/jest --runInBand --watchAll",
-    "test:ci": "node --experimental-vm-modules node_modules/.bin/jest --runInBand",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --watchAll",
+    "test:ci": "node --experimental-vm-modules node_modules/.bin/jest",
     "start": "tsc-watch --onsuccess \"node dist/src/index.js\""
   },
   "author": "Mohd Shukri Hasan",

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     - http
     image: semitechnologies/weaviate:latest
     ports:
-    - 8080:8080
+      - "8080"
     restart: on-failure:0
     environment:
       QUERY_DEFAULTS_LIMIT: 25

--- a/tests/lib/index.test.ts
+++ b/tests/lib/index.test.ts
@@ -4,21 +4,20 @@ import { WeaviateTestManager } from "../testUtils";
 import fs from 'fs/promises';
 
 
-const weaviateTestManager = new WeaviateTestManager();
-
-beforeEach(async () => {
-    await weaviateTestManager.deployWeaviate();
-
-});
-
-afterEach(async () => {
-
-    if (weaviateTestManager.environment) {
-        await weaviateTestManager.environment.down();
-    }
-}, 10000);
-
 describe("index node tests", () => {
+    let weaviateTestManager: WeaviateTestManager;
+
+    beforeEach(async () => {
+        weaviateTestManager = new WeaviateTestManager();
+        await weaviateTestManager.deployWeaviate();
+    });
+
+    afterEach(async () => {
+        if (weaviateTestManager.environment) {
+            await weaviateTestManager.environment.down();
+        }
+    });
+
     test("all documents end up in weaviate", async () => {
         const inputs = {
             dataFile: "./tests/data.json",
@@ -44,6 +43,7 @@ describe("index node tests", () => {
 
         const results = await board.runOnce(inputs);
         expect(results.totalIndexedDocuments).toBe(docCount);
+       
     });
 
     // Add more tests for the "index" node here

--- a/tests/lib/index.test.ts
+++ b/tests/lib/index.test.ts
@@ -21,7 +21,7 @@ describe("index node tests", () => {
     test("all documents end up in weaviate", async () => {
         const inputs = {
             dataFile: "./tests/data.json",
-            weaviateHost: "localhost:8080",
+            weaviateHost: weaviateTestManager.host,
             palmApiKey: process.env.PALM_APIKEY,
             className: "Book",
         };

--- a/tests/lib/query.test.ts
+++ b/tests/lib/query.test.ts
@@ -19,7 +19,7 @@ describe("query node tests", () => {
 
     test("search Harry Potter using vector search", async () => {
         const inputs = {
-            weaviateHost: "localhost:8080",
+            weaviateHost: weaviateTestManager.host,
             palmApiKey: process.env.PALM_APIKEY,
             query: `
                 a novice sorcerer uncovering his mystical lineage 
@@ -54,7 +54,7 @@ describe("query node tests", () => {
 
     test("search using raw graphql query", async () => {
         const inputs = {
-            weaviateHost: "localhost:8080",
+            weaviateHost: weaviateTestManager.host,
             palmApiKey: process.env.PALM_APIKEY,
             rawQuery: `
             {

--- a/tests/lib/query.test.ts
+++ b/tests/lib/query.test.ts
@@ -2,22 +2,21 @@ import { Board } from "@google-labs/breadboard";
 import WeaviateKit from "../../src/index";
 import { WeaviateTestManager } from "../testUtils";
 
-const weaviateTestManager = new WeaviateTestManager();
-
-beforeEach(async () => {
-    await weaviateTestManager.deployWeaviate();
-    await weaviateTestManager.importData();
-
-});
-
-afterEach(async () => {
-
-    if (weaviateTestManager.environment) {
-        await weaviateTestManager.environment.down();
-    }
-}, 10000);
-
 describe("query node tests", () => {
+    let weaviateTestManager: WeaviateTestManager;
+
+    beforeEach(async () => {
+        weaviateTestManager = new WeaviateTestManager();
+        await weaviateTestManager.deployWeaviate();
+        await weaviateTestManager.importData();
+    });
+
+    afterEach(async () => {
+        if (weaviateTestManager.environment) {
+            await weaviateTestManager.environment.down();
+        }
+    });
+
     test("search Harry Potter using vector search", async () => {
         const inputs = {
             weaviateHost: "localhost:8080",

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -10,7 +10,7 @@ import { DockerComposeEnvironment, StartedDockerComposeEnvironment, Wait } from 
 export class WeaviateTestManager {
     public client: WeaviateClient;
     public environment: StartedDockerComposeEnvironment;
-    private host: string;
+    public host: string;
     private scheme: string;
 
     /**
@@ -64,7 +64,11 @@ export class WeaviateTestManager {
             .withWaitStrategy("weaviate", Wait.forHttp("/v1/.well-known/ready", 8080))
             .up();
 
-        this.host = `${this.environment.getContainer("weaviate_1").getHost()}:8080`;
+        const weaviateContainer = this.environment.getContainer("weaviate_1");
+        const host = weaviateContainer.getHost();
+        const port = weaviateContainer.getMappedPort(8080);
+
+        this.host = `${host}:${port}`;
         this.scheme = "http";
         this.createClient();
         await this.createSchema();


### PR DESCRIPTION
Each test will now have its own dedicated weaviate instance. 

As such, there's no need to wait for a test to finish cleaning up its resources.